### PR TITLE
deploy.yaml: 不要なファイルコピー操作を削除

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,8 +27,6 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: "ビルド"
         run: pnpm run build
-      - name: "ファイルのコピー"
-        run: cp -r ./src/assets/data ./src/dist/assets/data
 
       - name: "artifactに保存する"
         id: deployment


### PR DESCRIPTION
## 概要
GitHub Actionsのdeploy.ymlで、存在しないディレクトリに対するファイルコピー操作が行われ、
ビルドエラーが発生していました。この操作を削除し、Viteの自動ビルド処理に依存するよう修正しました。

## 変更内容
- `.github/workflows/deploy.yaml`: 不要な手動ファイルコピー操作を削除

## 背景
`cp -r ./src/assets/data ./src/dist/assets/data` コマンドを実行しようとしましたが、
`src/assets/data` ディレクトリがプロジェクトに存在しないたい、
そのためエラーが発生しました。

Viteのビルドプロセスではアセットファイルが自動的に`dist/`ディレクトリに配置されるため、
手動でのファイルコピーは不要です。

## 影響範囲
- デプロイフローの実行回数が減少し、リソースも節約できます
- ビルド時のエラーが解消されます

## テスト
- ローカルから`pnpm run build`を実行し、生成されたdistディレクトリを確認しました
- GitHub Actionsでのビルド実行後に正しくデプロイされることを確認してください

Generated by: Vibe Kanban + OpenCode + glm-4.7-flash